### PR TITLE
Feature: Group posts by date, so they can be shown together

### DIFF
--- a/src/_includes/latestPost.njk
+++ b/src/_includes/latestPost.njk
@@ -1,22 +1,27 @@
-<article class="vs3">
-  <div class="vs2">
-    {# TODO: Subheading #}
-    <h2 class="mv0 f3 f2-ns fw6 lh-title">{{ latest.data.title }}</h2>
+<div class="vs4">
+  {% for post in latestPosts | reverse %}
+  <article class="vs3">
+    <div class="vs2">
+      {% Subheading level=2 %}
+        {{ post.data.title }}
+      {% endSubheading %}
 
-    <time class="db" datetime="{{latest.data.date}}">
-      {{latest.data.date | readableDate}}
-    </time>
-  </div>
+      <time class="db" datetime="{{post.data.date}}">
+        {{post.data.date | readableDate}}
+      </time>
+    </div>
 
-  {# Video #}
-  {% if latest.data.videoId %}
-      {# TODO: make videoId a parameter of youtubeVideo #}
-      {% set videoId = latest.data.videoId %}
-      {% include "youtubeVideo.njk" %}
-  {% endif %}
+    {# Video #}
+    {% if post.data.videoId %}
+        {# TODO: make videoId a parameter of youtubeVideo #}
+        {% set videoId = post.data.videoId %}
+        {% include "youtubeVideo.njk" %}
+    {% endif %}
 
-  {# Contents #}
-  {% MarkdownBlock %}
-    {{ latest.templateContent | safe }}
-  {% endMarkdownBlock %}
-</article>
+    {# Contents #}
+    {% MarkdownBlock %}
+      {{ post.templateContent | safe }}
+    {% endMarkdownBlock %}
+  </article>
+  {% endfor %}
+</div>

--- a/src/_includes/postslist.njk
+++ b/src/_includes/postslist.njk
@@ -1,5 +1,5 @@
 <ol reversed class="pa0 vs3 list postlist" style="counter-reset: start-from {{ postslist.length + 1 }}">
-{% for post in postslist | reverse %}
+{% for post in postslist %}
   <li class="flex items-baseline postlist-item{% if post.url == url %} fw7 postlist-item-active{% endif %}">
     <span class="ml2 lh-title">
       {# Title link #}

--- a/src/archive.njk
+++ b/src/archive.njk
@@ -13,7 +13,7 @@ permalink: /posts/
   {% endHeading %}
 
   <div class="measure-prose">
-    {% set postslist = collections.posts %}
+    {% set postslist = collections.posts | reverse %}
     {% include "postslist.njk" %}
   </div>
 </article>

--- a/src/index.njk
+++ b/src/index.njk
@@ -12,10 +12,10 @@ tags:
 <div class="vs5">
   <div class="vs4">
     {% Heading level=2 %}
-      Latest Talk
+      Latest Talks
     {% endHeading %}
 
-    {% set latest = collections.posts | last %}
+    {% set latestPosts = collections.postsByDate | last %}
     {% include "latestPost.njk" %}
   </div>
 
@@ -25,7 +25,8 @@ tags:
     {% endHeading %}
 
     <div class="measure-prose">
-      {% set postslist = collections.posts | head(-3) %}
+      {# For the "Past Talks", skip the latest talks, flatten the remaining, and take 3 #}
+      {% set postslist = collections.postsByDate | reverse | drop(1) | flatten | head(3) %}
       {% include "postslist.njk" %}
     </div>
 


### PR DESCRIPTION
From a discussion on Flowdock:

> I think the real issue to solve here is grouping. We often have 2 talks, so showing only 1 as the latest is a bit annoying. Could go grouping by date, and previewing all of them. The videos are loaded on-demand, so it wouldn't be any heavier than now.