### PR TITLE
Bugfix: Add Element.toggleAttribute polyfill

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,5 @@
 import Perfume from 'perfume.js';
+import * as polyfills from './polyfills';
 import * as analytics from './analytics';
 import * as animateMeButton from './animateMeButton';
 import * as youtubeVideo from './youtubeVideo';
@@ -6,6 +7,8 @@ import * as youtubeVideo from './youtubeVideo';
 /* The main entry point of the application */
 
 const init = () => {
+  polyfills.init();
+
   // Load custom tracking code
   // NOTE: Could be done lazily with import(), but
   // Rollup needs some setup to get that to work.

--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -1,0 +1,23 @@
+export function init() {
+  // toggleAttribute polyfill
+  // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute
+  if (!Element.prototype.toggleAttribute) {
+    Element.prototype.toggleAttribute = function(name, force) {
+      var forcePassed = arguments.length === 2;
+      var forceOn = !!force;
+      var forceOff = forcePassed && !force;
+
+      if (this.getAttribute(name) !== null) {
+        if (forceOn) return true;
+
+        this.removeAttribute(name);
+        return false;
+      } else {
+        if (forceOff) return false;
+
+        this.setAttribute(name, '');
+        return true;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Apparently this is not supported in some versions of Safari, which then crashes the scripts.
It doesn't affect much because the site is site anyway, but it's always a goal to make it work for more people!