### PR TITLE
Add infoscreen

### DIFF
--- a/src/info/index.njk
+++ b/src/info/index.njk
@@ -1,0 +1,28 @@
+---
+layout: layouts/base.njk
+title: Info
+templateClass: tmpl-post
+---
+
+<h1 class="mv5 mw5 center fill-accent fg-accent animation-logo animate-me">
+  {% include "svg/weeklies_logo.svg" %}
+</h1>
+
+<article class="pt4 pt5-ns pb4 vs4" contentEditable>
+  {% Heading level=1 %}
+    This week on Tech Weeklies
+  {% endHeading %}
+
+  <ol>
+    <li>
+      {% Text %}
+        Talk #1 – Click and edit
+      {% endText %}
+    </li>
+    <li>
+      {% Text %}
+        Talk #2 – Click and edit
+      {% endText %}
+    </li>
+  </ol>
+</article>


### PR DESCRIPTION
The idea behind this is that we would have a page /info or something that is not visible in the navigation.

This page could be used for displaying information about this weeks topics on the hangouts stream whenever setting up the stream in order to show some meaningful content in the stream before the event started. Future idea would be to add a button to play the Tech Weeklies Theme Song when that exists.

The `contentEditable` makes it easy to modify the text on that page without actually having to use dev-tools or deploy a new version.
