### PR TITLE
Feature/Add Podcast Page

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -29,13 +29,13 @@
   <body class="pa3 flex flex-column min-vh-100 mw7 center theme-dark fg-primary bg-secondary f-phantomsans">
     <header>
       {% include "SkipLink.njk" %}
-      <nav class="flex flex-row justify-between items-center flex-wrap">
-        <a class="db fg-accent-lighter fw7 link focus-outline-accent-lighter animation-cycle animate-me" href="{{ '/' | url }}">{{ metadata.title }}</a>
-        <ul class="ma0 pa0 flex list">
+      <nav class="mn2 flex flex-row justify-between items-center flex-wrap">
+        <a class="ma2 db fg-accent-lighter fw7 link focus-outline-accent-lighter animation-cycle animate-me" href="{{ '/' | url }}">{{ metadata.title }}</a>
+        <ul class="ma2 pa0 flex list">
           {%- for nav in collections.nav | reverse -%}
             {# Do not add home to the navigation #}
             {% if nav.url !== '/' %}
-            <li class="db ml3 {% if nav.url == page.url %} nav-item-active{% endif %}">
+            <li class="db mr3 {% if nav.url == page.url %} nav-item-active{% endif %}">
               <a
                 {% if nav.url == page.url %}aria-current="page"{% endif %}
                 class="fg-primary hover-fg-accent-lighter focus-outline-accent-lighter link"

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -314,3 +314,9 @@ a[href].tag:visited {
 .mn2 {
   margin: -0.5rem;
 }
+
+/* List styling */
+/* Keep list bullets flush with content on left */
+.u-list {
+  padding-left: 1em;
+}

--- a/src/podcast/index.njk
+++ b/src/podcast/index.njk
@@ -13,7 +13,7 @@ navtitle: Podcast
 
   <div class="vs4 measure-prose">
     {% Text %}
-      Tech Weeklies is also available as an audio-only podcast:
+      Tech Weeklies is also available as a video and audio-only podcast:
     {% endText %}
     <ul class="u-list vs3 f5 f4-ns">
       <li>

--- a/src/podcast/index.njk
+++ b/src/podcast/index.njk
@@ -1,0 +1,41 @@
+---
+layout: layouts/base.njk
+title: Podcast
+tags:
+  - nav
+navtitle: Podcast
+---
+
+<article class="pt4 pt5-ns pb4 vs4">
+  {% Heading level=1 %}
+    Podcast
+  {% endHeading %}
+
+  <div class="vs4 measure-prose">
+    {% Text %}
+      Tech Weeklies is also available as an audio-only podcast:
+    {% endText %}
+    <ul class="u-list vs3 f5 f4-ns">
+      <li>
+        {% Link href='https://itunes.apple.com/fi/podcast/futurice-tech-weeklies/id1449020155?mt=2', isExternal=true %}
+          On iTunes
+        {% endLink %}
+      </li>
+      <li>
+        {% Link href='https://www.google.com/podcasts?feed=aHR0cHM6Ly90ZWNod2Vla2xpZXMtcG9kY2FzdC5mdXR1cmljZS5jb20vZmVlZC54bWw%3D', isExternal=true %}
+          On Google Podcasts
+        {% endLink %}
+      </li>
+      <li>
+        {% Link href='https://techweeklies-podcast.futurice.com/feed.xml', isExternal=true %}
+          Direct feed URL
+        {% endLink %}
+      </li>
+      <li>
+        {% Link href='https://techweeklies-podcast.futurice.com/', isExternal=true %}
+          On PodBean
+        {% endLink %}
+      </li>
+    <ul>
+  </div>
+</article>


### PR DESCRIPTION
Adds the list of podcasts under `/podcast`.
Also tunes the navigation to accommodate the extra item. Now it scales more gracefully on narrow screens.