### PR TITLE
Hide dates from the frontpage

### DIFF
--- a/src/_includes/latestPost.njk
+++ b/src/_includes/latestPost.njk
@@ -7,10 +7,6 @@
           {{ post.data.title }}
         {% endLink %}
       {% endSubheading %}
-
-      <time class="db" datetime="{{post.data.date}}">
-        {{post.data.date | readableDate}}
-      </time>
     </div>
 
     {# Video #}

--- a/src/_includes/postslist.njk
+++ b/src/_includes/postslist.njk
@@ -11,8 +11,10 @@
         {% endif %}
       {% endLink %}
 
-      {# Date #}
-      <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate }}</time>
+      {% if showDate %}
+        {# Date #}
+        <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate }}</time>
+      {% endif %}
 
       {# Tags #}
       {% for tag in post.data.tags %}

--- a/src/archive.njk
+++ b/src/archive.njk
@@ -14,6 +14,7 @@ permalink: /posts/
 
   <div class="measure-prose">
     {% set postslist = collections.posts | reverse %}
+    {% set showDate = true %}
     {% include "postslist.njk" %}
   </div>
 </article>

--- a/src/index.njk
+++ b/src/index.njk
@@ -27,6 +27,7 @@ tags:
     <div class="measure-prose">
       {# For the "Past Talks", skip the latest talks, flatten the remaining, and take 3 #}
       {% set postslist = collections.postsByDate | reverse | drop(1) | flatten | head(3) %}
+      {% set showDate = false %}
       {% include "postslist.njk" %}
     </div>
 


### PR DESCRIPTION
The reasoning for this change is the following:

- Editing the videos takes time, they will not be very fresh when published
- Publishing to techweeklies.futurice.com is a manual process, sometimes even more delay caused by this fact
- We intentionally publish the videos with a bit of delay in order to never run out of content
- Dates on the frontpage makes some users feel that the page does not get updated
- Dates are not that relevant, the content most probably remains relevant for some months or years